### PR TITLE
Fix: #AR-7436 JWT Token fix for mobile Auth SDK

### DIFF
--- a/includes/text-snippets/flutter-get-start.md
+++ b/includes/text-snippets/flutter-get-start.md
@@ -67,6 +67,10 @@ Once initialized, you can call the `AuthProvider` functions for onboarding users
     }).catchError(...);
     ```
 
+    !!! tip "Arcana JWT Token"
+
+          {% include "./text-snippets/jwt_token.md" %}
+
     **Logout**
 
     Call the logout method in response to a user's choice to log out.  Once a user is authenticated, the Arcana wallet can be displayed in the context of the Flutter app. The Arcana wallet UI also provides an option to log out via the profile tab.

--- a/includes/text-snippets/react-native-get-start.md
+++ b/includes/text-snippets/react-native-get-start.md
@@ -66,7 +66,7 @@ Make sure that you specify the unique client ID assigned to the app during regis
     // For logging in
     const loginWithGoogle = () => {
       if(authRef !== null){
-        authRef.current.loginWithSocial().then(() => {
+        authRef.current.loginWithSocial("google").then(() => {
           // logged in
         }).catch(err => {
           // already logged in
@@ -75,6 +75,10 @@ Make sure that you specify the unique client ID assigned to the app during regis
       }
     }
     ```
+
+    !!! tip "Arcana JWT Token"
+
+          {% include "./text-snippets/jwt_token.md" %}
 
     **Logout**
 


### PR DESCRIPTION
# Pull Request Template

Resolves or continues [AR-7436](https://team-1624093970686.atlassian.net/browse/AR-7436).

## Blocking dependencies

NA

## Changes

JWT Token info added in Flutter and React-Native Guides:

See 'Onboarding tab content'

1. https://deploy-preview-80--arcana-docs.netlify.app/quick-start/flutter-quick-start#step-3-integrate-app
2. https://deploy-preview-80--arcana-docs.netlify.app/quick-start/react-native-quick-start#step-3-integrate-arcana-auth-react-native-sdk


When making primarily visual changes, it's helpful to include before and after screenshots.

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.


[AR-7436]: https://team-1624093970686.atlassian.net/browse/AR-7436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ