### PR TITLE
Fix: #AR-9424 refactoring for ca auth reports in separate sections

### DIFF
--- a/docs/audit/auth/index.md
+++ b/docs/audit/auth/index.md
@@ -1,0 +1,13 @@
+---
+alias: index-auth-audit-reports
+title: 'Audit Reports'
+description: 'Audit reports for Arcana Auth protocol.'
+arcana:
+  root_rel_path: ../..
+---
+
+# Audit Reports
+
+[ :material-plus-minus-box:{ .icon-color } Auth Smart Contracts](https://github.com/arcana-network/audit-reports/blob/main/REP-final-20221228T082421Z.pdf){ .md-button }
+
+[ :material-plus-minus-box:{ .icon-color } ADKG](https://github.com/arcana-network/audit-reports/blob/main/REP-final-20230228T054948Z.pdf){ .md-button }

--- a/docs/audit/ca/index.md
+++ b/docs/audit/ca/index.md
@@ -1,0 +1,13 @@
+---
+alias: index-ca-audit-reports
+title: 'Audit Reports'
+description: 'Audit reports for Arcana chain abstraction protocol.'
+arcana:
+  root_rel_path: ../..
+---
+
+# Audit Reports
+
+[ :material-plus-minus-box:{ .icon-color } Arcana Vault](https://github.com/arcana-network/audit-reports/blob/9b13233ce0fa4915c96c712bb49187864089f3df/Arcana%20Vault%20Final%20Report.pdf){ .md-button }
+
+[ :material-plus-minus-box:{ .icon-color } CA Wallet](https://github.com/arcana-network/audit-reports/blob/9b13233ce0fa4915c96c712bb49187864089f3df/Arcana%20Wallet%20Final%20Audit%20Report.pdf){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -499,7 +499,7 @@ nav:
       - CA Wagmi SDK: concepts/ca/ca_wagmi.md
       - Wagmi Plug & Play: concepts/ca/unified-balance-wagmi-pnp.md
     - Resources:
-      - CA Whitepaper: https://arcananetwork.notion.site/Chain-Abstraction-Technical-Whitepaper-121f11ed0804808da2e5cdd1432b2b61
+      - CA Whitepaper: https://arcananetwork.notion.site/Chain-Abstraction-Technical-Paper-121f11ed0804808da2e5cdd1432b2b61
       - Audit: 
         - audit/ca/index.md
         - Arcana Vault: https://github.com/arcana-network/audit-reports/blob/9b13233ce0fa4915c96c712bb49187864089f3df/Arcana%20Vault%20Final%20Report.pdf

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -500,7 +500,10 @@ nav:
       - Wagmi Plug & Play: concepts/ca/unified-balance-wagmi-pnp.md
     - Resources:
       - CA Whitepaper: https://arcananetwork.notion.site/Chain-Abstraction-Technical-Whitepaper-121f11ed0804808da2e5cdd1432b2b61
-      - CA Audit Report: https://github.com/arcana-network/audit-reports/blob/main/Arcana%20Wallet%20Final%20Audit%20Report.pdf
+      - Audit: 
+        - audit/ca/index.md
+        - Arcana Vault: https://github.com/arcana-network/audit-reports/blob/9b13233ce0fa4915c96c712bb49187864089f3df/Arcana%20Vault%20Final%20Report.pdf
+        - CA Wallet: https://github.com/arcana-network/audit-reports/blob/main/Arcana%20Wallet%20Final%20Audit%20Report.pdf
       - Release Notes: 
         - CA SDK: relnotes/latest-ca-release-note.md
         - CA Wagmi SDK: relnotes/latest-ca-wagmi-release-note.md
@@ -759,9 +762,10 @@ nav:
       - Validator Nodes: concepts/validator-nodes.md
     - Resources:
       - Auth Whitepaper: https://www.notion.so/Arcana-Technical-Docs-a1d7fd0d2970452586c693e4fee14d08
-      - Auth Audit Reports: 
-        - Arcana Smart Contracts: https://github.com/arcana-network/audit-reports/blob/main/REP-final-20221228T082421Z.pdf
-        - Arcana ADKG: https://github.com/arcana-network/audit-reports/blob/main/REP-final-20230228T054948Z.pdf
+      - Audit: 
+        - audit/auth/index.md
+        - Auth Smart Contracts: https://github.com/arcana-network/audit-reports/blob/main/REP-final-20221228T082421Z.pdf
+        - ADKG: https://github.com/arcana-network/audit-reports/blob/main/REP-final-20230228T054948Z.pdf
       - Release Notes: relnotes/latest-auth-release-note.md
       - Migration Guides: migration/latest-auth-migration-guide.md 
       - Changelog: changelog/index.md  


### PR DESCRIPTION
# Pull Request Template

Resolves or continues [AR-9424](https://team-1624093970686.atlassian.net/browse/AR-9424).

## Blocking dependencies

Is the report first page current? It says April 24 whereas description says Oct 24.

## Changes

- Added vault contract audit report in the audit repo (separate commit)
- Refactored how auth and ca reports are plugged in docs via that repo - multiple reports need an index page for nav else the user cannot see more than 1 report in the nav.



## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.


[AR-9424]: https://team-1624093970686.atlassian.net/browse/AR-9424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ