### PR TITLE
Fix: #AR-9617 BSC chain gas fee sponsorship cap limit updated

### DIFF
--- a/docs/faq/ca/faq.md
+++ b/docs/faq/ca/faq.md
@@ -440,7 +440,13 @@ arcana:
     Layer 1 chains such as Ethereum and Fuel require the user to pay for the gas fee
     and pay for the allowance set up transaction. For Layer 2 chains and Avalanche, 
     the gas fee required to make the allowance set up transaction is sponsored by
-    {{config.extra.arcana.company_name}} until further notice.
+    {{config.extra.arcana.company_name}} until further notice. 
+
+    !!! an-caution "Limited Gas Sponsorship"
+
+        The gas fee sponsored for the allowance setup transaction is limited. 
+        
+        For BSC chain, it is capped at $0.05. If gas fees are high at the time of allowance setup, then the allowance setup transaction may fail if the user does not have tokens to pay for the gas fee.
 
 ??? an-faq "Does the {{config.extra.arcana.company_name}} CA wallet allow any CA transactions?"
 

--- a/includes/text-snippets/ca/allowance_setup.md
+++ b/includes/text-snippets/ca/allowance_setup.md
@@ -8,3 +8,6 @@ have two allowance setup choices that differ by:
 |:---|:--- |:---|:---|:---|
 |1.|Ethereum Mainnet + Avalanche + L2 chains|Yes|`$1`-`$5` (as per current Ethereum Mainnet gas price)| Avalanche + L2 only|
 |2.|Avalanche + L2 chains|No|Nothing|All gas sponsored|
+|3.|Avalanche + L2 chains + BSC|No|Nothing|All gas sponsored^*^|
+
+^*^ For BSC chain, the gas fee for the allowance setup transaction is capped at $0.05. If gas fees are high, the allowance setup transaction may fail.


### PR DESCRIPTION
# Pull Request Template

Resolves or continues [AR-9617](https://team-1624093970686.atlassian.net/browse/AR-9617).

## Blocking dependencies

NA

## Changes

BSC chain allowance setup transaction gas fee sponsorship cap limit updated.


## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [ ] The changes have been tested locally.


[AR-9617]: https://team-1624093970686.atlassian.net/browse/AR-9617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ